### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Oauth, ID/PW 로그인 기능
 - 통합 회원 정보 관리
 ### [교직원 서비스](services/institution/README.md)
-### 학무보 서비스
+### 학부모 서비스
 ### 알림 서비스
 ## 🛠 Tech
 ### Architecture


### PR DESCRIPTION
## Summary
- update README parent service title

## Testing
- `bash gradlew test` *(fails: No route to host)*